### PR TITLE
Rdkb 62887

### DIFF
--- a/source/SnmpPlugin/ccsp_mib_utilities.c
+++ b/source/SnmpPlugin/ccsp_mib_utilities.c
@@ -85,6 +85,7 @@
 #include "ccsp_scalar_helper.h"
 #include "ccsp_table_helper.h"
 #include "ccsp_mib_utilities.h"
+#include "ccsp_snmp_debug.h"
 
 #include "ansc_xml_dom_parser_interface.h"
 #include "ansc_xml_dom_parser_external_api.h"

--- a/source/SnmpPlugin/ccsp_mib_utilities.c
+++ b/source/SnmpPlugin/ccsp_mib_utilities.c
@@ -34,8 +34,6 @@
 **********************************************************************/
 
 /*********************************************************************************
-
-#include "ccsp_snmp_debug.h"
     description:
 
         This is the implementation of utility functions used by

--- a/source/SnmpPlugin/ccsp_mib_utilities.c
+++ b/source/SnmpPlugin/ccsp_mib_utilities.c
@@ -35,6 +35,7 @@
 
 /*********************************************************************************
 
+#include "ccsp_snmp_debug.h"
     description:
 
         This is the implementation of utility functions used by
@@ -2047,7 +2048,7 @@ CcspUtilDMFilterToNamespace
 
 	if( !Cosa_FindDestComp(pBuffer, ppDestName, ppDestPath) || *ppDestName == NULL || *ppDestPath == NULL)
 	{
-		AnscTraceWarning(("Failed to find the CCSP component who supports '%s'\n", pBuffer));
+		AnscTraceDebug(("Failed to find the CCSP component who supports '%s'\n", pBuffer));
 
 		return insNumber;
 	}

--- a/source/SnmpPlugin/ccsp_scalar_helper_access.c
+++ b/source/SnmpPlugin/ccsp_scalar_helper_access.c
@@ -56,6 +56,7 @@
 #include "ccsp_scalar_helper.h"
 #include "ccsp_scalar_helper_internal.h"
 #include "ccsp_mib_utilities.h"
+#include "ccsp_snmp_debug.h"
 
 #include "ansc_load_library.h"
 #include "ansc_xml_dom_parser_interface.h"
@@ -656,7 +657,7 @@ CcspScalarHelperRefreshCache
 
 			if( !Cosa_FindDestComp(pDMString, &pThisObject->pCcspComp, &pThisObject->pCcspPath) )
 			{
-				AnscTraceWarning(("Failed to find the CCSP component who supports '%s'\n", pDMString));
+				AnscTraceDebug(("Failed to find the CCSP component who supports '%s'\n", pDMString));
 
 				return -1;
 			}

--- a/source/SnmpPlugin/ccsp_scalar_helper_control.c
+++ b/source/SnmpPlugin/ccsp_scalar_helper_control.c
@@ -54,6 +54,7 @@
 #include "ccsp_scalar_helper.h"
 #include "ccsp_scalar_helper_internal.h"
 #include "ccsp_mib_utilities.h"
+#include "ccsp_snmp_debug.h"
 
 #include "ansc_load_library.h"
 #include "ansc_xml_dom_parser_interface.h"
@@ -444,7 +445,7 @@ CcspScalarHelperRegisterMibHandler
                  mibHandler
                 );
 
-            AnscTraceInfo(("Register Cache handler successfully.\n"));
+            AnscTraceDebug(("Register Cache handler successfully.\n"));
         }
         entry = AnscQueueGetNextEntry(entry);
     }

--- a/source/SnmpPlugin/ccsp_table_helper_access.c
+++ b/source/SnmpPlugin/ccsp_table_helper_access.c
@@ -55,6 +55,7 @@
 #include "ccsp_table_helper.h"
 #include "ccsp_table_helper_internal.h"
 #include "ccsp_mib_utilities.h"
+#include "ccsp_snmp_debug.h"
 
 #include "ansc_load_library.h"
 #include "ansc_xml_dom_parser_interface.h"
@@ -1128,7 +1129,7 @@ CcspTableHelperRefreshCache
 
 		if( !Cosa_FindDestComp(pDMString, &pThisObject->pCcspComp, &pThisObject->pCcspPath) )
 		{
-			AnscTraceWarning(("Failed to find the CCSP component who supports '%s'\n", pDMString));
+			AnscTraceDebug(("Failed to find the CCSP component who supports '%s'\n", pDMString));
 
 			return -1;
 		}

--- a/source/SnmpPlugin/ccsp_table_helper_control.c
+++ b/source/SnmpPlugin/ccsp_table_helper_control.c
@@ -54,6 +54,7 @@
 #include "ccsp_table_helper.h"
 #include "ccsp_table_helper_internal.h"
 #include "ccsp_mib_utilities.h"
+#include "ccsp_snmp_debug.h"
 
 #include "ansc_load_library.h"
 #include "ansc_xml_dom_parser_interface.h"
@@ -574,7 +575,7 @@ CcspTableHelperRegisterMibHandler
         if (mibHandler)
             netsnmp_inject_handler( reg, mibHandler);
 
-        AnscTraceInfo(("Register Cache handler for Table Mibs successfully.\n"));
+        AnscTraceDebug(("Register Cache handler for Table Mibs successfully.\n"));
     }    
 }
 

--- a/source/SnmpPlugin/cosa_api.c
+++ b/source/SnmpPlugin/cosa_api.c
@@ -151,7 +151,7 @@ BOOL Cosa_GetParamValues
 	)
 {
 	
-                CcspTraceInfo(("RDKB_SNMP : SNMP GET called for param '%s'\n",*pParamArray));     
+                CcspTraceDebug(("RDKB_SNMP : SNMP GET called for param '%s'\n",*pParamArray));     
 		int							iStatus = 0;
 		iStatus = 
 			CcspBaseIf_getParameterValues
@@ -171,7 +171,7 @@ BOOL Cosa_GetParamValues
                 else
                 {
                    
-                CcspTraceInfo(("RDKB_SNMP : SNMP GET SUCCESS for param '%s'\n",*pParamArray));
+                CcspTraceDebug(("RDKB_SNMP : SNMP GET SUCCESS for param '%s'\n",*pParamArray));
                 }            
 		return iStatus == CCSP_SUCCESS;
 }

--- a/source/custom/ccsp_snmp_common.c
+++ b/source/custom/ccsp_snmp_common.c
@@ -36,6 +36,7 @@
 
 #include "cosa_api.h"
 #include "ccsp_snmp_common.h"
+#include "ccsp_snmp_debug.h"
 #include "safec_lib_common.h"
 
 
@@ -58,7 +59,7 @@ int get_dm_value(const char *param, char *val, size_t len)
     
     //Get Destination component 
     if(!Cosa_FindDestComp((char *)param, &ppDestComponentName, &ppDestPath)){
-        AnscTraceWarning(("Failed to find the CCSP component who supports '%s'\n", param));
+        AnscTraceDebug(("Failed to find the CCSP component who supports '%s'\n", param));
         goto get_negative_result;
     }
     
@@ -111,7 +112,7 @@ int set_dm_value(const char *param, char *val, size_t vlen)
     }
     
     if (!Cosa_FindDestComp((char *)param, &ppDestComponentName, &ppDestPath)){
-        AnscTraceWarning(("Failed to find the CCSP component who supports '%s'\n", param));
+        AnscTraceDebug(("Failed to find the CCSP component who supports '%s'\n", param));
 
         goto set_negative_result;
     }

--- a/source/include/ccsp_snmp_debug.h
+++ b/source/include/ccsp_snmp_debug.h
@@ -22,11 +22,22 @@
 
 #include <stdio.h>
 
-#undef  AnscTraceDebug
-#define AnscTraceDebug(a)                                    \
+#ifndef CCSP_SNMP_DEBUG_TRACE
+#if defined(CCSP_SNMP_ENABLE_DEBUG_PRINT)
+#define CCSP_SNMP_DEBUG_TRACE(a)                             \
     do {                                                     \
         printf("%s:%d> ", __FUNCTION__, __LINE__);           \
         printf a;                                            \
     } while (0)
+#else
+#define CCSP_SNMP_DEBUG_TRACE(a)                             \
+    do {                                                     \
+    } while (0)
+#endif
+#endif
+
+#ifndef AnscTraceDebug
+#define AnscTraceDebug(a) CCSP_SNMP_DEBUG_TRACE(a)
+#endif
 
 #endif

--- a/source/include/ccsp_snmp_debug.h
+++ b/source/include/ccsp_snmp_debug.h
@@ -1,0 +1,32 @@
+/*
+ * If not stated otherwise in this file or this component's Licenses.txt file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2015 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _CCSP_SNMP_DEBUG_H
+#define _CCSP_SNMP_DEBUG_H
+
+#include <stdio.h>
+
+#undef  AnscTraceDebug
+#define AnscTraceDebug(a)                                    \
+    do {                                                     \
+        printf("%s:%d> ", __FUNCTION__, __LINE__);           \
+        printf a;                                            \
+    } while (0)
+
+#endif


### PR DESCRIPTION
To reduce logging in SNMP module.
https://ccp.sys.comcast.net/browse/RDKB-62887

Reason for change: To reduce logging in SNMP module. https://ccp.sys.comcast.net/browse/RDKB-62887
Test Procedure: We should not see the Repeated logs with Deafult Log Level Info.
Risks: Low
Priority: P1
Signed-off-by: Jayasri Kadiyala [Jayasri_Kadiyala@comcast.com](mailto:Jayasri_Kadiyala@comcast.com)