### PR TITLE
RDKCOM-5588: RDKBDEV-3441: Missing WiFi parameters while querying WiFi snmp mibs

### DIFF
--- a/source/custom/rg_wifi_handler.c
+++ b/source/custom/rg_wifi_handler.c
@@ -1818,8 +1818,6 @@ find_retry:
          if( netsnmp_tdata_add_row(table, row) != SNMPERR_SUCCESS )
          goto ret;
          }
-   if(row)
-   netsnmp_tdata_remove_and_delete_row(table, row);
    return status;        
 
 ret:


### PR DESCRIPTION
Reason for change:
    Upstream code changes to list all WiFi parameters while querying WiFi snmp mibs

Test Procedure: Updated in JIRA
Risks: None
Signed-off-by: Anjana B Rajan <anjanab_rajan@askey.com>
